### PR TITLE
useVersion("latest") resolves to maven-metadata <latest>

### DIFF
--- a/hytale/source/HytaleServerPlatform.kt
+++ b/hytale/source/HytaleServerPlatform.kt
@@ -11,6 +11,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 
 class HytaleServerPlatform() : HytaleGradle.ConfigurePlatform {
@@ -87,9 +88,24 @@ class HytaleServerPlatform() : HytaleGradle.ConfigurePlatform {
                 it.url = project.uri("https://maven.hytale.com/${patchline.repo}")
             }
         }
-        with(project.dependencies) {
-            log.lifecycle("> Deps :${project.name}.implementation('com.hypixel.hytale:Server:$version')")
-            add("implementation", "com.hypixel.hytale:Server:$version")
+        val versionDisplay = if (version == "latest") "<latest, resolved lazily from maven-metadata.xml>" else version
+        log.lifecycle("> Deps :${project.name}.implementation('com.hypixel.hytale:Server:$versionDisplay')")
+        project.dependencies.addProvider(
+            "implementation",
+            serverVersionProvider().map { "com.hypixel.hytale:Server:$it" }
+        )
+    }
+
+    private fun serverVersionProvider(): Provider<String> {
+        if (version != "latest") {
+            return project.provider { version }
+        }
+        val patchlineRepo = patchline.repo
+        return project.providers.of(MavenMetadataLatestVersion::class.java) { spec ->
+            spec.parameters.metadataUrl.set(
+                "https://maven.hytale.com/$patchlineRepo/com/hypixel/hytale/Server/maven-metadata.xml"
+            )
+            spec.parameters.fallback.set("+")
         }
     }
 

--- a/hytale/source/MavenMetadataLatestVersion.kt
+++ b/hytale/source/MavenMetadataLatestVersion.kt
@@ -1,0 +1,74 @@
+// Copyright © Ádám Liszkai, "Kicsivazz" - MIT in LICENSE.md - SPDX-License-Identifier: MIT
+
+package dev.scaffoldit.hytale
+
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamConstants
+
+/**
+ * Resolves the version published as `<latest>` in a Maven `maven-metadata.xml`.
+ *
+ * Gradle's `+` / `latest.integration` / `latest.release` selectors all sort the
+ * `<versions>` list by Gradle's StaticVersionComparator and ignore `<latest>`,
+ * so a publisher who switches version schemes (e.g. `2026.05.07-abc` → `0.5.0-pre.8`)
+ * sees Gradle pick an older build. Fetching `<latest>` directly honors the
+ * publisher's intent. See gradle/gradle#9141.
+ *
+ * Implemented as a `ValueSource` so the HTTP fetch participates in the Gradle
+ * configuration cache rather than running on every configuration phase.
+ */
+abstract class MavenMetadataLatestVersion :
+    ValueSource<String, MavenMetadataLatestVersion.Parameters> {
+
+    interface Parameters : ValueSourceParameters {
+        val metadataUrl: Property<String>
+        val fallback: Property<String>
+    }
+
+    override fun obtain(): String {
+        val log = Logging.getLogger(MavenMetadataLatestVersion::class.java)
+        val url = parameters.metadataUrl.get()
+        val fallback = parameters.fallback.get()
+        return try {
+            when (val latest = readLatestElement(url)) {
+                null -> {
+                    log.warn("> Hytale: $url missing <latest> tag, falling back to '$fallback'")
+                    fallback
+                }
+                else -> {
+                    log.lifecycle("> Hytale: useVersion(\"latest\") resolved to '$latest' via maven-metadata.xml")
+                    latest
+                }
+            }
+        } catch (e: Exception) {
+            log.warn("> Hytale: could not read $url, falling back to '$fallback': ${e.message}")
+            fallback
+        }
+    }
+
+    private fun readLatestElement(url: String): String? {
+        val factory = XMLInputFactory.newInstance().apply {
+            setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+            setProperty(XMLInputFactory.SUPPORT_DTD, false)
+        }
+        java.net.URI(url).toURL().openStream().use { stream ->
+            val reader = factory.createXMLStreamReader(stream)
+            try {
+                while (reader.hasNext()) {
+                    if (reader.next() == XMLStreamConstants.START_ELEMENT &&
+                        reader.localName == "latest"
+                    ) {
+                        return reader.elementText
+                    }
+                }
+            } finally {
+                reader.close()
+            }
+        }
+        return null
+    }
+}

--- a/hytale/source/wire/HytaleGradle.kt
+++ b/hytale/source/wire/HytaleGradle.kt
@@ -17,7 +17,7 @@ object HytaleGradle {
 
         var version: String
         fun useVersion(version: String) {
-            this.version = version.replace("latest", "+")
+            this.version = version
             HytaleExtension.version = this.version
         }
 


### PR DESCRIPTION
With Hypixel switching versioning to semver, Gradle apparently trips up. Noticed when working on a mod, that after `0.5.0-pre.8` got released and I'm building a pre-release mod, the Assets and devserver threw a bunch of errors.

Ran an investigation and found that Gradle's `+` defaults to a numeric comparison.

Most likely should be fixed upstream, but noticed that it's not fixed yet there, and figured it might be more suitable to fix here, as it's actually more of a Hypixel's oversight of how their version scheme change affects Maven versions list sorting in Gradle.